### PR TITLE
Integrate Headroom.js for mobile header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+node_modules/
+.DS_Store
+.env
+
+# production
+/dist
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vs code
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-headroom": "^3.2.1",
         "react-remove-scroll": "^2.7.1"
       },
       "devDependencies": {
@@ -1664,6 +1665,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/lightningcss": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
@@ -1903,6 +1910,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -1987,6 +2006,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2135,6 +2169,26 @@
         }
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -2155,6 +2209,26 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-headroom": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-headroom/-/react-headroom-3.2.1.tgz",
+      "integrity": "sha512-C+7bmTwmHWIOjU1r5aSLm4tAQKjmqW4PB65tHllE/D6h+If1+V3gy83BOvp46OCo25LtJJlLa/HDs7Eq5OPFgA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.8",
+        "raf": "^3.3.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -2229,6 +2303,12 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-remove-scroll": "^2.7.1"
+    "react-remove-scroll": "^2.7.1",
+    "react-headroom": "^3.2.1"
   },
   "scripts": {
     "start": "vite",

--- a/src/components/Layout/Header/Header.jsx
+++ b/src/components/Layout/Header/Header.jsx
@@ -1,19 +1,17 @@
 import { useState, useEffect, useRef } from "react";
 import { TABLET } from "../../../constants/breakpoints";
 import useThrottledEvent from "../../../hooks/useThrottledEvent";
+import Headroom from "react-headroom";
 import HeaderNav from "./HeaderNav";
 import TabsContent from "./TabsContent";
 
 const Header = () => {
   const [activeTab, setActiveTab] = useState(null);
-  const [isSticky, setIsSticky] = useState(window.innerWidth <= TABLET);
   const [isMobile, setIsMobile] = useState(false);
-  const [showMobileTabs, setShowMobileTabs] = useState(false);
   const [showCloseText, setShowCloseText] = useState({});
   const [isHeaderHovered, setIsHeaderHovered] = useState(false);
   const [isContentHovered, setIsContentHovered] = useState(false);
   const headerRef = useRef(null);
-  const lastScrollTop = useRef(0);
   const languageRef = useRef(null);
 
   const tabs = [
@@ -44,13 +42,9 @@ const Header = () => {
   const handleResize = () => {
     setIsMobile(window.innerWidth <= TABLET);
     if (window.innerWidth > TABLET) {
-      setIsSticky(true); // Toujours sticky sur desktop
       setShowCloseText({});
-    } else {
-      setIsSticky(true); // Sticky sur mobile aussi mais par logique mobile
-      if (activeTab !== null) {
-        setShowCloseText({ [activeTab]: true });
-      }
+    } else if (activeTab !== null) {
+      setShowCloseText({ [activeTab]: true });
     }
   };
 
@@ -59,37 +53,6 @@ const Header = () => {
   }, []);
 
   useThrottledEvent("resize", handleResize, 200);
-
-  // Toujours sticky sur mobile/tablette au chargement ou si resize vers mobile/tablette
-  useEffect(() => {
-    if (window.innerWidth <= TABLET) {
-      setIsSticky(true);
-    }
-  }, [isMobile]);
-
-  const handleScroll = () => {
-    if (activeTab) return; // Don't change sticky when a tab is open
-    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-
-    if (window.innerWidth > TABLET) {
-      setIsSticky(true); // Always sticky on desktop
-      return;
-    }
-
-    if (scrollTop < lastScrollTop.current) {
-      // Scrolling up
-      setIsSticky(true);
-      setShowMobileTabs(false);
-    } else if (scrollTop > lastScrollTop.current) {
-      // Scrolling down
-      setIsSticky(false);
-      setShowMobileTabs(true);
-    }
-
-    lastScrollTop.current = scrollTop <= 0 ? 0 : scrollTop;
-  };
-
-  useThrottledEvent("scroll", handleScroll, 100);
 
   // Handle tab interactions
   const handleTabMouseOver = (tabId) => {
@@ -166,20 +129,24 @@ const Header = () => {
 
   return (
     <>
-      <HeaderNav
-        headerRef={headerRef}
-        isSticky={isSticky}
-        tabs={tabs}
-        activeTab={activeTab}
-        showCloseText={showCloseText}
-        handleTabMouseOver={handleTabMouseOver}
-        handleTabClick={handleTabClick}
-        handleLanguageClick={handleLanguageClick}
-        languageRef={languageRef}
-        showMobileTabs={showMobileTabs}
-        onHeaderMouseEnter={() => setIsHeaderHovered(true)}
-        onHeaderMouseLeave={() => setIsHeaderHovered(false)}
-      />
+      <Headroom
+        tolerance={{ up: 10, down: 10 }}
+        disableInlineStyles
+        wrapperStyle={{ position: "relative", zIndex: "var(--z-header)" }}
+      >
+        <HeaderNav
+          headerRef={headerRef}
+          tabs={tabs}
+          activeTab={activeTab}
+          showCloseText={showCloseText}
+          handleTabMouseOver={handleTabMouseOver}
+          handleTabClick={handleTabClick}
+          handleLanguageClick={handleLanguageClick}
+          languageRef={languageRef}
+          onHeaderMouseEnter={() => setIsHeaderHovered(true)}
+          onHeaderMouseLeave={() => setIsHeaderHovered(false)}
+        />
+      </Headroom>
       <TabsContent
         activeTab={activeTab}
         tabs={tabs}

--- a/src/components/Layout/Header/Header.module.css
+++ b/src/components/Layout/Header/Header.module.css
@@ -6,7 +6,7 @@
 }
 
 /* --- HEADER PRINCIPAL --- */
-.header {
+.headroom {
   position: fixed;
   top: 0;
   left: 0;
@@ -15,13 +15,21 @@
   max-width: 100%;
   height: 8vh;
   z-index: var(--z-header);
-  background-color: var(--secondary-color);
-  transform: translateY(-100%);
   transition: transform 0.3s ease;
-  overflow-x: hidden;
 }
-.header.sticky {
+
+.headroom--unpinned {
+  transform: translateY(-100%);
+}
+
+.headroom--pinned {
   transform: translateY(0);
+}
+
+.header {
+  background-color: var(--secondary-color);
+  height: 8vh;
+  overflow-x: hidden;
 }
 
 /* --- GRILLE DU HEADER --- */
@@ -392,7 +400,9 @@
     box-shadow: 0 -6px 100px 16px var(--primary-color);
     align-items: stretch;
   }
-  .mobileTabsContainer.visible { transform: translateY(100%); }
+  .headroom--unpinned + .mobileTabsContainer {
+    transform: translateY(100%);
+  }
   .tab {
     min-height: 0;
     padding: 0;

--- a/src/components/Layout/Header/HeaderNav.jsx
+++ b/src/components/Layout/Header/HeaderNav.jsx
@@ -5,7 +5,6 @@ import { TABLET } from "../../../constants/breakpoints";
 
 const HeaderNav = ({
   headerRef,
-  isSticky,
   tabs,
   activeTab,
   showCloseText,
@@ -13,14 +12,13 @@ const HeaderNav = ({
   handleTabClick,
   handleLanguageClick,
   languageRef,
-  showMobileTabs,
   onHeaderMouseEnter,
   onHeaderMouseLeave,
 }) => (
   <>
     <header
       ref={headerRef}
-      className={`${styles.header} ${isSticky ? styles.sticky : ""}`}
+      className={styles.header}
       onMouseEnter={onHeaderMouseEnter}
       onMouseLeave={onHeaderMouseLeave}
     >
@@ -69,11 +67,7 @@ const HeaderNav = ({
         </div>
       </div>
     </header>
-    <div
-      className={`${styles.mobileTabsContainer} ${
-        showMobileTabs ? styles.visible : ""
-      }`}
-    >
+    <div className={styles.mobileTabsContainer}>
       {tabs.map((tab) => (
         <TabButton
           key={tab.id}


### PR DESCRIPTION
## Summary
- add `react-headroom` dependency
- ignore node_modules with `.gitignore`
- simplify header scroll logic and wrap navigation in `<Headroom>`
- remove sticky state logic from `HeaderNav`
- update CSS to use Headroom classes

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68763e2ede18832e9b561d4ca247089f