### PR TITLE
Fix mobile header resizing

### DIFF
--- a/src/components/Layout/Header/Header.module.css
+++ b/src/components/Layout/Header/Header.module.css
@@ -13,7 +13,7 @@
   right: 0;
   width: 100%;
   max-width: 100%;
-  height: 8vh;
+  height: calc(var(--vh, 1vh) * 8);
   z-index: var(--z-header);
   background-color: var(--secondary-color);
   transform: translateY(-100%);
@@ -50,7 +50,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 8vh;
+  height: calc(var(--vh, 1vh) * 8);
 }
 .logoContainer {
   display: flex;
@@ -108,7 +108,7 @@
 .navigation {
   display: flex;
   align-items: stretch;
-  height: 8vh;
+  height: calc(var(--vh, 1vh) * 8);
   width: 100%;
 }
 .tabsContainer, .desktopTabsContainer {
@@ -173,7 +173,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 8vh;
+  height: calc(var(--vh, 1vh) * 8);
 }
 
 .languageButton {
@@ -196,12 +196,12 @@
 /* --- TABS CONTENT (MOBILE/TABLET) --- */
 .tabsContent {
   position: fixed;
-  top: 8vh;
+  top: calc(var(--vh, 1vh) * 8);
   left: 0;
   right: 0;
-  bottom: 16vh;
+  bottom: calc(var(--vh, 1vh) * 16);
   width: 100%;
-  height: calc(100vh - 24vh);
+  height: calc((var(--vh, 1vh) * 100) - calc(var(--vh, 1vh) * 24));
   z-index: var(--z-content);
   display: none;
   opacity: 0;
@@ -355,7 +355,7 @@
   }
 
   .header {
-    height: 8vh;
+    height: calc(var(--vh, 1vh) * 8);
     max-width: 100%;
     overflow-x: hidden;
     transform: none;
@@ -369,7 +369,7 @@
   .languageSection {
     display: flex;
     justify-content: center;
-    height: 8vh;
+    height: calc(var(--vh, 1vh) * 8);
   }
   .navigation { width: 100%; height: auto; display: contents; }
   .desktopTabsContainer { display: none; }
@@ -382,7 +382,7 @@
     width: 100%;
     grid-template-columns: repeat(6, 1fr);
     grid-template-rows: none;
-    height: 16vh;
+    height: calc(var(--vh, 1vh) * 16);
     background-color: var(--secondary-color);
     z-index: var(--z-tabs);
     padding: 0;
@@ -437,7 +437,7 @@
 /* --- RESPONSIVE MOBILE --- */
 @media (max-width: 767px) {
   .header {
-    height: 10vh;
+    height: calc(var(--vh, 1vh) * 10);
     max-width: 100%;
   }
 
@@ -450,7 +450,7 @@
     width: 100%;
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(2, 1fr);
-    height: 8vh;
+    height: calc(var(--vh, 1vh) * 8);
     background-color: var(--secondary-color);
     z-index: var(--z-tabs);
     padding: 0;
@@ -462,11 +462,11 @@
   }
 
   .mobileTabsContainer {
-    height: 12vh;
+    height: calc(var(--vh, 1vh) * 12);
   }
   .logoSection,
   .languageSection {
-    height: 10vh;
+    height: calc(var(--vh, 1vh) * 10);
   }
   .logoMain, .logoSub, .languageButton {
     font-size: var(--font-size-base);
@@ -476,9 +476,9 @@
     padding: 0;
   }
   .tabsContent {
-    top: 10vh !important;
-    bottom: 12vh !important;
-    height: calc(100vh - 22vh) !important;
+    top: calc(var(--vh, 1vh) * 10) !important;
+    bottom: calc(var(--vh, 1vh) * 12) !important;
+    height: calc((var(--vh, 1vh) * 100) - calc(var(--vh, 1vh) * 22)) !important;
     background-color: var(--secondary-color);
   }
 }
@@ -494,11 +494,11 @@
 @media (min-width: 992px) {
   .tabsContent {
     position: fixed;
-    top: 8vh;
+    top: calc(var(--vh, 1vh) * 8);
     left: 0;
     right: 0;
     height: auto;
-    max-height: 100vh;
+    max-height: calc(var(--vh, 1vh) * 100);
     display: flex;
     justify-content: center;
     align-items: flex-start;
@@ -592,7 +592,7 @@
     padding: 0 0.25rem;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
-        padding-bottom: 16vh;
+        padding-bottom: calc(var(--vh, 1vh) * 16);
   }
 
     .tab {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,20 @@ import ReactDOM from 'react-dom/client';
 import './styles/globals.css';
 import App from './App.jsx';
 
+// Set --vh custom property for mobile viewport height
+const setVh = () => {
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+};
+setVh();
+let prevWidth = window.innerWidth;
+window.addEventListener('resize', () => {
+  if (window.innerWidth !== prevWidth) {
+    prevWidth = window.innerWidth;
+    setVh();
+  }
+});
+
 // Create root element
 const root = ReactDOM.createRoot(document.getElementById('root'));
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -158,6 +158,8 @@ body,
   --white: #ffffff;
   --black: #000000;
   --transparent: transparent;
+  /* Viewport unit fallback */
+  --vh: 1vh;
 
   /* Palette */
   --primary-color: #141414;


### PR DESCRIPTION
## Summary
- lock header height on mobile using a custom `--vh` unit
- update stylesheet to use the custom unit
- set `--vh` from JS on load and on width resize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876ad134de4832ea1556c08f5bc9730