### PR TITLE
Fix scroll jitter in Firefox/Brave

### DIFF
--- a/src/components/Layout/Header/Header.jsx
+++ b/src/components/Layout/Header/Header.jsx
@@ -58,7 +58,7 @@ const Header = () => {
     handleResize();
   }, []);
 
-  useThrottledEvent("resize", handleResize, 200);
+  useThrottledEvent("resize", handleResize, 200, { passive: true });
 
   // Toujours sticky sur mobile/tablette au chargement ou si resize vers mobile/tablette
   useEffect(() => {
@@ -67,20 +67,25 @@ const Header = () => {
     }
   }, [isMobile]);
 
+  const MIN_SCROLL_DELTA = 10;
   const handleScroll = () => {
     if (activeTab) return; // Don't change sticky when a tab is open
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    const delta = scrollTop - lastScrollTop.current;
+
+    if (Math.abs(delta) < MIN_SCROLL_DELTA) return;
 
     if (window.innerWidth > TABLET) {
       setIsSticky(true); // Always sticky on desktop
+      lastScrollTop.current = scrollTop <= 0 ? 0 : scrollTop;
       return;
     }
 
-    if (scrollTop < lastScrollTop.current) {
+    if (delta < 0) {
       // Scrolling up
       setIsSticky(true);
       setShowMobileTabs(false);
-    } else if (scrollTop > lastScrollTop.current) {
+    } else if (delta > 0) {
       // Scrolling down
       setIsSticky(false);
       setShowMobileTabs(true);
@@ -89,7 +94,7 @@ const Header = () => {
     lastScrollTop.current = scrollTop <= 0 ? 0 : scrollTop;
   };
 
-  useThrottledEvent("scroll", handleScroll, 100);
+  useThrottledEvent("scroll", handleScroll, 50, { passive: true });
 
   // Handle tab interactions
   const handleTabMouseOver = (tabId) => {

--- a/src/components/Layout/Header/Header.module.css
+++ b/src/components/Layout/Header/Header.module.css
@@ -16,12 +16,14 @@
   height: calc(var(--vh, 1vh) * 8);
   z-index: var(--z-header);
   background-color: var(--secondary-color);
-  transform: translateY(-100%);
   transition: transform 0.3s ease;
   overflow-x: hidden;
+  will-change: transform;
+  transform: translateY(-100%) translateZ(0);
 }
 .header.sticky {
-  transform: translateY(0);
+  transform: translateY(0) translateZ(0);
+  transition-delay: 0.1s;
 }
 
 /* --- GRILLE DU HEADER --- */
@@ -387,12 +389,13 @@
     z-index: var(--z-tabs);
     padding: 0;
     gap: 0;
-    transform: translateY(0);
+    transform: translateY(0) translateZ(0);
     transition: transform 0.3s ease;
     box-shadow: 0 -6px 100px 16px var(--primary-color);
     align-items: stretch;
+    will-change: transform;
   }
-  .mobileTabsContainer.visible { transform: translateY(100%); }
+  .mobileTabsContainer.visible { transform: translateY(100%) translateZ(0); }
   .tab {
     min-height: 0;
     padding: 0;
@@ -441,7 +444,7 @@
     max-width: 100%;
   }
 
-    .mobileTabsContainer {
+  .mobileTabsContainer {
     display: grid;
     position: fixed;
     bottom: 0;
@@ -455,10 +458,11 @@
     z-index: var(--z-tabs);
     padding: 0;
     gap: 0;
-    transform: translateY(0);
+    transform: translateY(0) translateZ(0);
     transition: transform 0.3s ease;
     box-shadow: 0 -6px 100px 16px var(--primary-color);
     align-items: stretch;
+    will-change: transform;
   }
 
   .mobileTabsContainer {

--- a/src/hooks/useThrottledEvent.js
+++ b/src/hooks/useThrottledEvent.js
@@ -1,6 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef } from "react";
 
-export default function useThrottledEvent(eventName, handler, delay = 100) {
+export default function useThrottledEvent(
+  eventName,
+  handler,
+  delay = 100,
+  options = { passive: false },
+) {
   const lastCall = useRef(0);
   const savedHandler = useRef(handler);
 
@@ -17,7 +22,7 @@ export default function useThrottledEvent(eventName, handler, delay = 100) {
       }
     };
 
-    window.addEventListener(eventName, listener);
-    return () => window.removeEventListener(eventName, listener);
-  }, [eventName, delay]);
+    window.addEventListener(eventName, listener, options);
+    return () => window.removeEventListener(eventName, listener, options);
+  }, [eventName, delay, options]);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -142,6 +142,7 @@
 html {
   font-size: 16px;
   scroll-behavior: smooth;
+  overscroll-behavior: none;
 }
 
 html,
@@ -231,6 +232,7 @@ body {
   min-height: 100vh;
   scrollbar-gutter: stable;
   overflow-x: hidden;
+  overscroll-behavior: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   width: 100%;


### PR DESCRIPTION
## Summary
- make scroll/resize listeners passive
- ignore tiny scroll movements when toggling sticky header
- hint GPU acceleration for fixed elements
- disable page overscroll bounce

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877709ea1c0832eb5a65da0cbf05404