### PR TITLE
Add mobile scroll lock section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,12 @@ import HeroSlider from "./components/Home/HeroSlider/HeroSlider";
 import ContentGrid from "./components/Home/ContentGrid/ContentGrid";
 import StunningSection from "./components/Home/StunningSection/stunningsection";
 import ArticleSection from "./components/Home/ArticleSection/ArticleSection";
-{/* import ProjectsBlock from "./components/Home/ProjectsBlock/ProjectsBlock"; */}
+{
+  /* import ProjectsBlock from "./components/Home/ProjectsBlock/ProjectsBlock"; */
+}
 import InSituCards from "./components/Home/InSituCards/InSituCards";
 import { inSituCards } from "./components/Home/InSituCards/inSituData";
+import ScrollLockSection from "./components/Common/ScrollLockSection/ScrollLockSection";
 
 function App() {
   useEffect(() => {
@@ -43,6 +46,8 @@ function App() {
         <div className="w-full h-[4vh] hidden" />
       </main>
       <Footer />
+      {/* Section used to lock scroll on mobile/tablet */}
+      <ScrollLockSection />
     </div>
   );
 }

--- a/src/components/Common/ScrollLockSection/ScrollLockSection.jsx
+++ b/src/components/Common/ScrollLockSection/ScrollLockSection.jsx
@@ -1,0 +1,23 @@
+import React, { useRef } from "react";
+import useScrollLockSection from "../../../hooks/useScrollLockSection";
+import styles from "./ScrollLockSection.module.css";
+
+/**
+ * Section that prevents further scrolling on mobile/tablet. It should be
+ * rendered just after the site footer.
+ */
+const ScrollLockSection = () => {
+  const sentinelRef = useRef(null);
+  useScrollLockSection(sentinelRef);
+
+  return (
+    <>
+      {/* Invisible element observed for scroll position */}
+      <div ref={sentinelRef} className={styles.sentinel} aria-hidden="true" />
+      {/* Hidden 100vh section with primary background */}
+      <section className={styles.lockSection} aria-hidden="true" />
+    </>
+  );
+};
+
+export default ScrollLockSection;

--- a/src/components/Common/ScrollLockSection/ScrollLockSection.module.css
+++ b/src/components/Common/ScrollLockSection/ScrollLockSection.module.css
@@ -1,0 +1,17 @@
+.sentinel {
+  width: 100%;
+  height: 1px;
+}
+
+.lockSection {
+  width: 100%;
+  height: calc(var(--vh, 1vh) * 100);
+  background-color: var(--primary-color);
+}
+
+@media (min-width: 992px) {
+  .sentinel,
+  .lockSection {
+    display: none;
+  }
+}

--- a/src/hooks/useScrollLockSection.js
+++ b/src/hooks/useScrollLockSection.js
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useCallback } from "react";
+import { TABLET } from "../constants/breakpoints";
+import useThrottledEvent from "./useThrottledEvent";
+
+/**
+ * Prevents scrolling past the sentinel element. When the user reaches the
+ * sentinel (typically placed just before a hidden section), the scroll position
+ * is locked so the section never becomes visible. Scrolling upward remains
+ * possible. Active only on screens up to the TABLET breakpoint.
+ */
+export default function useScrollLockSection(sentinelRef) {
+  const lockPos = useRef(0);
+
+  // Compute scroll position at which to lock
+  const updateLockPosition = useCallback(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    lockPos.current = rect.top + window.scrollY - window.innerHeight;
+  }, [sentinelRef]);
+
+  // Scroll handler clamps the scroll position when threshold is reached
+  const handleScroll = useCallback(() => {
+    if (window.innerWidth <= TABLET && window.scrollY >= lockPos.current) {
+      window.scrollTo(0, lockPos.current);
+    }
+  }, []);
+
+  // Attach throttled scroll listener
+  useThrottledEvent("scroll", handleScroll, 16);
+
+  // Recompute positions on mount and resize
+  useEffect(() => {
+    updateLockPosition();
+    window.addEventListener("resize", updateLockPosition);
+    return () => {
+      window.removeEventListener("resize", updateLockPosition);
+    };
+  }, [updateLockPosition]);
+}


### PR DESCRIPTION
## Summary
- add `useScrollLockSection` hook to clamp scroll when hitting bottom sentinel
- create `ScrollLockSection` component with 100vh primary-colored section
- integrate the scroll lock section after the footer in `App.jsx`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68779816ea10832e84db871851cd3c31