### PR TITLE
Improve mobile scroll handling

### DIFF
--- a/src/components/Layout/Header/Header.jsx
+++ b/src/components/Layout/Header/Header.jsx
@@ -78,7 +78,7 @@ const Header = () => {
     }
   }, [isMobile]);
 
-  const MIN_SCROLL_DELTA = 10;
+  const MIN_SCROLL_DELTA = 15;
   const handleScroll = () => {
     if (activeTab) return; // Don't change sticky when a tab is open
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop;

--- a/src/components/Layout/Header/Header.module.css
+++ b/src/components/Layout/Header/Header.module.css
@@ -14,6 +14,7 @@
   width: 100%;
   max-width: 100%;
   height: calc(var(--vh, 1vh) * 8);
+  height: 8dvh;
   z-index: var(--z-header);
   background-color: var(--secondary-color);
   transition: transform 0.3s ease;
@@ -53,6 +54,7 @@
   align-items: center;
   justify-content: center;
   height: calc(var(--vh, 1vh) * 8);
+  height: 8dvh;
 }
 .logoContainer {
   display: flex;
@@ -111,6 +113,7 @@
   display: flex;
   align-items: stretch;
   height: calc(var(--vh, 1vh) * 8);
+  height: 8dvh;
   width: 100%;
 }
 .tabsContainer, .desktopTabsContainer {
@@ -176,6 +179,7 @@
   align-items: center;
   justify-content: center;
   height: calc(var(--vh, 1vh) * 8);
+  height: 8dvh;
 }
 
 .languageButton {
@@ -199,11 +203,14 @@
 .tabsContent {
   position: fixed;
   top: calc(var(--vh, 1vh) * 8);
+  top: 8dvh;
   left: 0;
   right: 0;
   bottom: calc(var(--vh, 1vh) * 16);
+  bottom: 16dvh;
   width: 100%;
   height: calc((var(--vh, 1vh) * 100) - calc(var(--vh, 1vh) * 24));
+  height: calc(100dvh - 24dvh);
   z-index: var(--z-content);
   display: none;
   opacity: 0;
@@ -358,6 +365,7 @@
 
   .header {
     height: calc(var(--vh, 1vh) * 8);
+    height: 8dvh;
     max-width: 100%;
     overflow-x: hidden;
     transform: none;
@@ -372,6 +380,7 @@
     display: flex;
     justify-content: center;
     height: calc(var(--vh, 1vh) * 8);
+    height: 8dvh;
   }
   .navigation { width: 100%; height: auto; display: contents; }
   .desktopTabsContainer { display: none; }
@@ -385,6 +394,7 @@
     grid-template-columns: repeat(6, 1fr);
     grid-template-rows: none;
     height: calc(var(--vh, 1vh) * 16);
+    height: 16dvh;
     background-color: var(--secondary-color);
     z-index: var(--z-tabs);
     padding: 0;
@@ -441,6 +451,7 @@
 @media (max-width: 767px) {
   .header {
     height: calc(var(--vh, 1vh) * 10);
+    height: 10dvh;
     max-width: 100%;
   }
 
@@ -454,6 +465,7 @@
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(2, 1fr);
     height: calc(var(--vh, 1vh) * 8);
+    height: 8dvh;
     background-color: var(--secondary-color);
     z-index: var(--z-tabs);
     padding: 0;
@@ -467,10 +479,12 @@
 
   .mobileTabsContainer {
     height: calc(var(--vh, 1vh) * 12);
+    height: 12dvh;
   }
   .logoSection,
   .languageSection {
     height: calc(var(--vh, 1vh) * 10);
+    height: 10dvh;
   }
   .logoMain, .logoSub, .languageButton {
     font-size: var(--font-size-base);
@@ -481,8 +495,11 @@
   }
   .tabsContent {
     top: calc(var(--vh, 1vh) * 10) !important;
+    top: 10dvh !important;
     bottom: calc(var(--vh, 1vh) * 12) !important;
+    bottom: 12dvh !important;
     height: calc((var(--vh, 1vh) * 100) - calc(var(--vh, 1vh) * 22)) !important;
+    height: calc(100dvh - 22dvh) !important;
     background-color: var(--secondary-color);
   }
 }
@@ -499,10 +516,12 @@
   .tabsContent {
     position: fixed;
     top: calc(var(--vh, 1vh) * 8);
+    top: 8dvh;
     left: 0;
     right: 0;
     height: auto;
     max-height: calc(var(--vh, 1vh) * 100);
+    max-height: 100dvh;
     display: flex;
     justify-content: center;
     align-items: flex-start;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,20 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './styles/globals.css';
 import App from './App.jsx';
 
-// Set --vh custom property for mobile viewport height
-const setVh = () => {
-  const vh = window.innerHeight * 0.01;
-  document.documentElement.style.setProperty('--vh', `${vh}px`);
-};
-setVh();
-let prevWidth = window.innerWidth;
-window.addEventListener('resize', () => {
-  if (window.innerWidth !== prevWidth) {
-    prevWidth = window.innerWidth;
-    setVh();
-  }
-});
-
 // Create root element
 const root = ReactDOM.createRoot(document.getElementById('root'));
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -141,8 +141,8 @@
 
 html {
   font-size: 16px;
-  scroll-behavior: smooth;
-  overscroll-behavior: none;
+  scroll-behavior: auto;
+  overscroll-behavior: contain;
 }
 
 html,
@@ -160,7 +160,7 @@ body,
   --black: #000000;
   --transparent: transparent;
   /* Viewport unit fallback */
-  --vh: 1vh;
+  --vh: 1dvh;
 
   /* Palette */
   --primary-color: #141414;
@@ -232,7 +232,8 @@ body {
   min-height: 100vh;
   scrollbar-gutter: stable;
   overflow-x: hidden;
-  overscroll-behavior: none;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   width: 100%;


### PR DESCRIPTION
## Summary
- tweak CSS scroll settings for mobile browsers
- remove JS vh polyfill and rely on modern 100dvh
- adjust header scroll delta

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877df127a98832eb34f2e0f4b29e57e